### PR TITLE
Fix COMPILE

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -38,12 +38,12 @@ then
       fi
       ;;
     *)
-      COMPILE="-W"
+      COMPILE="$CC-W"
       if [ $debug = yes ]
       then
-	COMPILE="$COMPILE -g"
+	COMPILE="$CC -g"
       else
-	COMPILE="$COMPILE -O -DNDEBUG"
+	COMPILE="$CC -O -DNDEBUG"
       fi
       ;;
   esac


### PR DESCRIPTION
Hi,

There was something off here. I tried to fix it the best I could. Trying to use this for work, but on a `nix` system, things don't line up.  Without this patch, I'm getting:

```
[matesoos@athena runlim]$ ./configure.sh 
[configure.sh] -W -O -DNDEBUG -DVERSION=\\"2.0.0rc8\\"
[configure.sh] installation prefix '/usr/local/bin'

[matesoos@athena runlim]$ make
W -O -DNDEBUG -DVERSION=\"2.0.0rc8\" -o runlim runlim.c -lpthread
make: W: No such file or directory
make: [makefile:3: runlim] Error 127 (ignored)
W -O -DNDEBUG -DVERSION=\"2.0.0rc8\" -o runlim-remount-proc runlim-remount-proc.c
make: W: No such file or directory
make: [makefile:5: runlim-remount-proc] Error 127 (ignored)
```

With this patch, all works. Probably not the best patch, but I think it's broken actually. Maybe not. Sorry for the noise.

Mate